### PR TITLE
removes pickle utilities in rsl_rl training

### DIFF
--- a/scripts/rsl_rl/train.py
+++ b/scripts/rsl_rl/train.py
@@ -89,7 +89,7 @@ from isaaclab.envs import (
     multi_agent_to_single_agent,
 )
 from isaaclab.utils.dict import print_dict
-from isaaclab.utils.io import dump_pickle, dump_yaml
+from isaaclab.utils.io import dump_yaml
 from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlVecEnvWrapper
 from isaaclab_tasks.utils import get_checkpoint_path
 from isaaclab_tasks.utils.hydra import hydra_task_config
@@ -177,8 +177,6 @@ def main(env_cfg: ManagerBasedRLEnvCfg | DirectRLEnvCfg | DirectMARLEnvCfg, agen
     # dump the configuration into log-directory
     dump_yaml(os.path.join(log_dir, "params", "env.yaml"), env_cfg)
     dump_yaml(os.path.join(log_dir, "params", "agent.yaml"), agent_cfg)
-    dump_pickle(os.path.join(log_dir, "params", "env.pkl"), env_cfg)
-    dump_pickle(os.path.join(log_dir, "params", "agent.pkl"), agent_cfg)
 
     # run training
     runner.learn(num_learning_iterations=agent_cfg.max_iterations, init_at_random_ep_len=True)


### PR DESCRIPTION
## 📝 Description
Removes pickle utilities in rsl_rl train.py script.
IsaacLab 0.47 (2025-10-14) drops pickle due to security risks 
see: https://isaac-sim.github.io/IsaacLab/main/source/refs/changelog.html

## 🛠 Type of Change
- Maintenance or dependency update

## Before PR
```
python scripts/random_agent.py --task SO-ARM100-Reach-Play-v0
..starting sequence...
Traceback (most recent call last):
  File "/workspace/isaac_so_arm101/scripts/rsl_rl/train.py", line 92, in <module>
    from isaaclab.utils.io import dump_pickle, dump_yaml
ImportError: cannot import name 'dump_pickle' from 'isaaclab.utils.io' (/workspace/isaaclab/source/isaaclab/isaaclab/utils/io/__init__.py)
```

## 🧪 Testing
- Rerun `python scripts/random_agent.py --task SO-ARM100-Reach-Play-v0`
- Simulation boots up into GUI and executes the task without the error

## ✅ Checklist
- [x] I’ve run `pre-commit` on all modified files
- [x] I’ve tested in simulation or verified that changes don’t break expected behavior
- [] I’ve updated documentation where needed
- [x] I’ve reviewed open issues to ensure this is not a duplicate
- [x] Code follows the repository’s style and structure


## Question
A quick grep search shows that dump_pickle() is also used in skrl.
I guess this will break there as well.
Should this also be removed?

```
isaac_so_arm101# grep -r dump_pickle .
./scripts/skrl/train.py:from isaaclab.utils.io import dump_pickle, dump_yaml
./scripts/skrl/train.py:    dump_pickle(os.path.join(log_dir, "params", "env.pkl"), env_cfg)
./scripts/skrl/train.py:    dump_pickle(os.path.join(log_dir, "params", "agent.pkl"), agent_cfg)
```