### PR TITLE
minimal_height=0.01. Accelerated the training speed of Isaac-SO-ARM10…

### DIFF
--- a/src/isaac_so_arm101/tasks/lift/lift_env_cfg.py
+++ b/src/isaac_so_arm101/tasks/lift/lift_env_cfg.py
@@ -159,7 +159,7 @@ class RewardsCfg:
 
     reaching_object = RewTerm(func=mdp.object_ee_distance, params={"std": 0.05}, weight=1.0)
 
-    lifting_object = RewTerm(func=mdp.object_is_lifted, params={"minimal_height": 0.04}, weight=15.0)
+    lifting_object = RewTerm(func=mdp.object_is_lifted, params={"minimal_height": 0.01}, weight=15.0)
 
     object_goal_tracking = RewTerm(
         func=mdp.object_goal_distance,


### PR DESCRIPTION
I compared Isaac-SO-ARM100-Lift-Cube-v0 with Isaac-Lift-Cube-Franka-v0 example in IsaacLab
The Franka example trains much faster, and its lifting_object reward starts at 0.1200 right from the beginning and increases quickly.

The Franka environment uses a 4 cm cube, while isaac_so_arm101 uses a 1.5 cm cube.
But both of them use the same minimal_height = 4 cm in the lifting reward.

So I changed the minimal_height in isaac_so_arm101 to 1.5 cm. （1 cm is even better)
After that, training sped up a lot, and the robot started showing grasping behavior within 10 minutes.
